### PR TITLE
[MAINT-914] Expose types in exports map

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "engines": {
     "node": "24.13.0"
   },
-  "version": "0.4.9",
+  "version": "0.4.11",
   "files": [
     "dist"
   ],
@@ -14,9 +14,11 @@
   "typings": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/saguaro.es.js",
       "require": "./dist/saguaro.umd.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Description
`trainual` is moving its `tsconfig` `moduleResolution` from `Node` to `bundler` (required for Storybook 10, MAINT 914). Under bundler resolution TypeScript resolves a bare import of saguaro through the exports map, which only lists import and require conditions. With no types condition TypeScript finds no declarations, every saguaro import becomes implicit any, and the styled components DefaultTheme augmentation in dist/lib/types/SaguaroTheme.d.ts is dropped, which cascades into ~500 type errors in trainual.

This adds the types condition pointing at dist/index.d.ts, the same file the top level types field already points at, plus a package.json export. Old resolution modes keep using the top level field, so nothing changes for current consumers. Runtime entry points are untouched. Version bumped to 0.4.11 for the next tag.
