### PR TITLE
fix: read Storybook workflow node from .node-version

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     # Job steps
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Set up Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
-          node-version: 16.20.0
+          node-version-file: .node-version
       - name: Install dependencies
         run: yarn
       - name: Configure AWS credentials


### PR DESCRIPTION
## Description

The Storybook S3 deploy workflow failed on main because `setup-node` pinned node 16.20.0 while `package.json` engines require 24.13.0, so yarn refused to install:

```
error saguaro@0.4.11: The engine "node" is incompatible with this module. Expected version "24.13.0". Got "16.20.0"
```

Failing run: https://github.com/trainual/saguaro/actions/runs/28965821557

Points `setup-node` at the committed `.node-version` file (24.13.0) so CI, `package.json` engines, and local nvm share one source. Also bumps `checkout` and `setup-node` from v1 to v4.

No version bump: the change touches only CI, not `src` or `dist`, so nothing consumers pull differs from v0.4.11.

## How to test this change?

Merge to main and confirm the Publish Storybook to S3 workflow installs deps and deploys.