### PR TITLE
fix: replace removed storybook-deployer with aws s3 sync

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -27,7 +27,9 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
-      - name: Deploy storybook to s3
-        run: yarn deploy-storybook
+      - name: Build storybook
+        run: yarn build-storybook
         env:
           NODE_OPTIONS: --max-old-space-size=7680
+      - name: Deploy storybook to s3
+        run: aws s3 sync storybook-static/ s3://saguaro-storybook --delete

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+storybook-static

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "preview": "vite preview",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "deploy-storybook": "storybook-to-aws-s3 --bucket-path saguaro-storybook --aws-profile NONE",
     "prepack": "json -f package.json -I -e \"delete this.devDependencies; delete this.dependencies\""
   },
   "dependencies": {


### PR DESCRIPTION
## Problem

The "Publish Storybook to S3" workflow has failed on every push to `main` since November. The deploy step ran `yarn deploy-storybook`, which calls `storybook-to-aws-s3` from `@storybook/storybook-deployer` — but that package was removed in 9c49098 during the Storybook 8 vulnerability upgrade, so the binary doesn't exist and the step exits 127.

## Fix

The deployer is deprecated and unmaintained, so rather than reinstalling it:

- Workflow now runs `yarn build-storybook` (keeping the `NODE_OPTIONS` memory bump), then `aws s3 sync storybook-static/ s3://saguaro-storybook --delete`. Same target as before — the old deployer passed `--bucket-path` verbatim into `s3://<bucket-path>`. The AWS CLI is preinstalled on runners and uses the credentials the workflow already configures.
- Removed the dead `deploy-storybook` script from package.json.
- Added `storybook-static` to `.gitignore` (wasn't ignored).

## Verification

`yarn build-storybook` builds clean locally and outputs to `storybook-static/`. The workflow only triggers on push to `main`, so the deploy itself proves out after merge — worth watching the first run.